### PR TITLE
garbage collect underlying memory allocation in buffer implementation 

### DIFF
--- a/common/buffer.c
+++ b/common/buffer.c
@@ -76,3 +76,16 @@ int buffer_write (struct buffer *b, const void *s, buflen_t len)
   buffer_wseek (b, len);
   return 1;
 }
+
+int buffer_free(struct buffer *b)
+{
+  if (b && b->data) {
+    b->start = b->end = b->size = 0;
+    free(b->data);
+    b->data = NULL;
+
+    return 0;
+  }
+
+  return -1;
+}

--- a/common/buffer.h
+++ b/common/buffer.h
@@ -13,3 +13,4 @@ void buffer_rseek (struct buffer *b, buflen_t n);
 buflen_t buffer_wpeek (struct buffer *b, uint8_t **s);
 void buffer_wseek (struct buffer *b, buflen_t n);
 int buffer_write (struct buffer *b, const void *s, buflen_t len);
+int buffer_free (struct buffer *b);

--- a/common/l_buffer.c
+++ b/common/l_buffer.c
@@ -159,6 +159,13 @@ static int lua_buffer_debug (lua_State *L)
   return 1;
 }
 
+static int lua_buffer_free (lua_State *L)
+{
+  struct lua_buffer *lb = luaL_checkudata (L, 1, lua_buffer_mt);
+  buffer_free(&(lb->b));
+  return 0;
+}
+
 static const struct luaL_reg functions[] = {
   {"new",  lua_buffer_new },
   {NULL,   NULL           },
@@ -175,6 +182,7 @@ static const struct luaL_reg buffer_methods[] = {
   {"rseek",      lua_buffer_rseek      },
   {"_debug",     lua_buffer_debug      },
   {"__len",      lua_buffer_len        },
+  {"__gc",       lua_buffer_free       },
   {NULL,         NULL                  },
 };
 


### PR DESCRIPTION
Resizable data buffer is missing "__gc" implementation which may cause memory leaks in case buffers are frequently allocated.